### PR TITLE
Add initial support for fetching info from GitHub for Sirius Desktop

### DIFF
--- a/stuart/pom.xml
+++ b/stuart/pom.xml
@@ -266,7 +266,12 @@
 	  <artifactId>google-auth-library-oauth2-http</artifactId>
 	  <version>0.20.0</version>
 	</dependency>
-	<!-- // -->
+	<dependency>
+		<groupId>com.spotify</groupId>
+		<artifactId>github-client</artifactId>
+		<version>0.2.9</version>
+	</dependency>
+		<!-- // -->
   </dependencies>
 
 

--- a/stuart/src/main/java/fr/obeo/tools/stuart/github/GitHubPullRequestLogger.java
+++ b/stuart/src/main/java/fr/obeo/tools/stuart/github/GitHubPullRequestLogger.java
@@ -1,0 +1,42 @@
+package fr.obeo.tools.stuart.github;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+import java.util.Objects;
+
+import com.spotify.github.v3.clients.GitHubClient;
+import com.spotify.github.v3.prs.requests.ImmutablePullRequestParameters;
+import com.spotify.github.v3.prs.requests.PullRequestParameters;
+
+import fr.obeo.tools.stuart.Post;
+
+public class GitHubPullRequestLogger {
+    private static final String GITHUB_PR_ICON = "https://raw.githubusercontent.com/primer/octicons/main/icons/git-pull-request-24.svg";
+
+    private final String token;
+
+    private final GitHubClient githubClient;
+    
+    public GitHubPullRequestLogger(String token) {
+        this.token = Objects.requireNonNull(token);
+        this.githubClient = GitHubClient.create(URI.create("https://api.github.com/"), this.token);
+    }
+
+    public Collection<Post> getPatchsets(String orgName, String repoName) {
+        List<Post> posts = new ArrayList<>();
+        var prClient = githubClient.createRepositoryClient(orgName, repoName).createPullRequestClient();
+        PullRequestParameters parameters = ImmutablePullRequestParameters.builder().state("open").build();
+        prClient.list(parameters).join().forEach(pr -> {
+            String url = pr.htmlUrl().toString();
+            Date createdAt = new Date(pr.createdAt().instant().toEpochMilli());
+            Post newPost = Post.createPost(url, pr.title(), pr.user().login(), GITHUB_PR_ICON, createdAt);
+            newPost.setQuote(false);
+            newPost.mightBeTruncated(false);
+            posts.add(newPost);
+        });
+        return posts;
+    }
+}

--- a/stuart/src/test/java/fr/obeo/tools/stuart/EclipseMattermostInstanceTest.java
+++ b/stuart/src/test/java/fr/obeo/tools/stuart/EclipseMattermostInstanceTest.java
@@ -419,8 +419,8 @@ public class EclipseMattermostInstanceTest {
 			Date daysAgo = getDateXDaysAgo(nbDays);
 			List<Post> posts = Lists.newArrayList();
 			posts.addAll(new GitLogger(new File(storage + "/clones/")).getMergedCommits(daysAgo,
-					"https://git.eclipse.org/r/sirius/org.eclipse.sirius",
-					"https://git.eclipse.org/c/sirius/org.eclipse.sirius.git/commit/?id="));
+					"https://github.com/eclipse-sirius/sirius-desktop.git",
+					"https://github.com/eclipse-sirius/sirius-desktop/commit/"));
 			posts.addAll(new EclipseForumsLogger().collectPosts(262, daysAgo));
 
 			posts.addAll(

--- a/stuart/src/test/java/fr/obeo/tools/stuart/EclipseMattermostInstanceTest.java
+++ b/stuart/src/test/java/fr/obeo/tools/stuart/EclipseMattermostInstanceTest.java
@@ -22,6 +22,7 @@ import fr.obeo.tools.stuart.bugzilla.BugzillaLogger;
 import fr.obeo.tools.stuart.eclipseforum.EclipseForumsLogger;
 import fr.obeo.tools.stuart.gerrit.GerritLogger;
 import fr.obeo.tools.stuart.git.GitLogger;
+import fr.obeo.tools.stuart.github.GitHubPullRequestLogger;
 import fr.obeo.tools.stuart.jenkins.JenkinsLogger;
 import fr.obeo.tools.stuart.mattermost.MattermostEmitter;
 import fr.obeo.tools.stuart.rss.RssLogger;
@@ -407,7 +408,8 @@ public class EclipseMattermostInstanceTest {
 		}
 
 		String channel = System.getenv("MATTERMOST_CHANNEL");
-		if (channel != null) {
+		String token = System.getenv("GITHUB_TOKEN");
+		if (channel != null && token != null) {
 			MattermostEmitter emitter = new MattermostEmitter("https", host, channel);
 
 			int nbDays = 3;
@@ -425,8 +427,7 @@ public class EclipseMattermostInstanceTest {
 
 			posts.addAll(
 					new JenkinsLogger("https://ci.eclipse.org/sirius/", daysAgo).getBuildResults(trace.keySet()));
-			posts.addAll(new GerritLogger("https://git.eclipse.org/r")
-					.getPatchsets(Sets.newHashSet("sirius/org.eclipse.sirius"), nbDays));
+			posts.addAll(new GitHubPullRequestLogger(token).getPatchsets("eclipse-sirius", "sirius-desktop"));
 			posts.addAll(
 					new BugzillaLogger("https://bugs.eclipse.org/bugs", Sets.newHashSet("genie", "genie@eclipse.org"))
 							.bugzillaLog(3, Sets.newHashSet("Sirius")));


### PR DESCRIPTION
Completely untested for the moment...

- Get latest Sirius (Desktop) commit info from GitHub
- Fetch open PRs on Sirius Desktop
